### PR TITLE
Performence improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2018"
 
 [dependencies]
 eui48 = "0.4.6"
-bytes = "0.5.4"
 byteorder = "1.3.4"
 
 [dev-dependencies]

--- a/src/control/mod.rs
+++ b/src/control/mod.rs
@@ -1,19 +1,21 @@
 use super::*;
-use bytes::Bytes;
+use std::borrow::Cow;
 
-pub struct ControlFrame {
-    bytes: Bytes,
+pub struct ControlFrame<'a> {
+    bytes: Cow<'a, [u8]>,
 }
 
-impl ControlFrame {
-    pub fn new(bytes: Bytes) -> Self {
-        Self { bytes }
+impl<'a> ControlFrame<'a> {
+    pub fn new<T: Into<Cow<'a, [u8]>>>(bytes: T) -> Self {
+        Self {
+            bytes: bytes.into(),
+        }
     }
 }
 
-impl FrameTrait for ControlFrame {
-    fn bytes(&self) -> Bytes {
-        self.bytes.clone()
+impl FrameTrait for ControlFrame<'_> {
+    fn bytes(&self) -> &[u8] {
+        self.bytes.as_ref()
     }
 
     fn addr1(&self) -> MacAddress {
@@ -24,7 +26,7 @@ impl FrameTrait for ControlFrame {
         None
     }
 }
-impl ControlFrameTrait for ControlFrame {}
+impl ControlFrameTrait for ControlFrame<'_> {}
 
 pub trait ControlFrameTrait: FrameTrait {
     fn addr2(&self) -> MacAddress {

--- a/src/data/builder.rs
+++ b/src/data/builder.rs
@@ -21,7 +21,7 @@ impl DataFrameBuilder {
 
     #[must_use]
     pub fn build(&self) -> DataFrame {
-        DataFrame::new(self.bytes().to_vec())
+        DataFrame::new(self.bytes())
     }
 
     pub fn next_layer(&mut self, data: &[u8]) {

--- a/src/data/mod.rs
+++ b/src/data/mod.rs
@@ -2,20 +2,20 @@ mod builder;
 
 pub use self::builder::*;
 use super::*;
-use bytes::Bytes;
+use std::borrow::Cow;
 
-pub struct DataFrame {
-    bytes: Bytes,
+pub struct DataFrame<'a> {
+    bytes: Cow<'a, [u8]>,
 }
 
-impl DataFrame {
-    pub fn new<T: Into<Bytes>>(bytes: T) -> Self {
+impl<'a> DataFrame<'a> {
+    pub fn new<T: Into<Cow<'a, [u8]>>>(bytes: T) -> Self {
         Self {
             bytes: bytes.into(),
         }
     }
 
-    pub fn next_layer(&self) -> Option<Bytes> {
+    pub fn next_layer(&self) -> Option<&[u8]> {
         let mut index = Self::FRAGMENT_SEQUENCE_START + 2;
 
         if self.protected() {
@@ -33,13 +33,13 @@ impl DataFrame {
             _ => unreachable!(),
         }
 
-        Some(self.bytes().slice(index..))
+        Some(&self.bytes()[index..])
     }
 }
 
-impl FrameTrait for DataFrame {
-    fn bytes(&self) -> Bytes {
-        self.bytes.clone()
+impl FrameTrait for DataFrame<'_> {
+    fn bytes(&self) -> &[u8] {
+        self.bytes.as_ref()
     }
 
     fn addr1(&self) -> MacAddress {
@@ -55,8 +55,8 @@ impl FrameTrait for DataFrame {
         }
     }
 }
-impl FragmentSequenceTrait for DataFrame {}
-impl DataFrameTrait for DataFrame {}
+impl FragmentSequenceTrait for DataFrame<'_> {}
+impl DataFrameTrait for DataFrame<'_> {}
 
 pub trait DataFrameTrait: FrameTrait {
     fn addr2(&self) -> MacAddress {

--- a/src/frame/builder.rs
+++ b/src/frame/builder.rs
@@ -20,7 +20,7 @@ impl FrameBuilder {
 
     #[must_use]
     pub fn build(&self) -> Frame {
-        Frame::new(self.bytes().to_vec())
+        Frame::new(self.bytes())
     }
 }
 impl FrameBuilderTrait for FrameBuilder {

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -26,8 +26,12 @@ impl<'a> Frame<'a> {
             FrameType::Management => {
                 Some(FrameLayer::Management(ManagementFrame::new(self.bytes())))
             }
-            FrameType::Control => Some(FrameLayer::Control(ControlFrame::new(self.bytes()))),
-            FrameType::Data => Some(FrameLayer::Data(DataFrame::new(self.bytes()))),
+            FrameType::Control => {
+                Some(FrameLayer::Control(ControlFrame::new(self.bytes())))
+            },
+            FrameType::Data => {
+                Some(FrameLayer::Data(DataFrame::new(self.bytes())))
+            },
             _ => None,
         }
     }

--- a/src/frame/mod.rs
+++ b/src/frame/mod.rs
@@ -3,25 +3,25 @@ mod builder;
 pub use self::builder::*;
 use super::*;
 use byteorder::{ByteOrder, LittleEndian};
-use bytes::Bytes;
+use std::borrow::Cow;
 
-pub enum FrameLayer {
-    Management(ManagementFrame),
-    Control(ControlFrame),
-    Data(DataFrame),
+pub enum FrameLayer<'a> {
+    Management(ManagementFrame<'a>),
+    Control(ControlFrame<'a>),
+    Data(DataFrame<'a>),
 }
 
-pub struct Frame {
-    bytes: Bytes,
+pub struct Frame<'a> {
+    bytes: Cow<'a, [u8]>,
 }
-impl Frame {
-    pub fn new<T: Into<Bytes>>(bytes: T) -> Self {
+impl<'a> Frame<'a> {
+    pub fn new<T: Into<Cow<'a, [u8]>>>(bytes: T) -> Self {
         Self {
             bytes: bytes.into(),
         }
     }
 
-    pub fn next_layer(&self) -> Option<FrameLayer> {
+    pub fn next_layer(&self) -> Option<FrameLayer<'_>> {
         match self.type_() {
             FrameType::Management => {
                 Some(FrameLayer::Management(ManagementFrame::new(self.bytes())))
@@ -32,14 +32,15 @@ impl Frame {
         }
     }
 }
-impl FrameTrait for Frame {
-    fn bytes(&self) -> Bytes {
-        self.bytes.clone()
+
+impl FrameTrait for Frame<'_> {
+    fn bytes(&self) -> &[u8] {
+        self.bytes.as_ref()
     }
 }
 
 pub trait FrameTrait {
-    fn bytes(&self) -> Bytes;
+    fn bytes(&self) -> &[u8];
 
     fn version(&self) -> FrameVersion {
         FrameVersion::from_u8(self.bytes()[0] & 0b0000_0011)
@@ -130,6 +131,7 @@ pub trait FrameTrait {
     // Addressing
 
     fn addr1(&self) -> MacAddress {
+        // Unwrap is fine since this function only returns an error when the length is wrong.
         MacAddress::from_bytes(&self.bytes()[4..10]).unwrap()
     }
 

--- a/src/management/association_request/mod.rs
+++ b/src/management/association_request/mod.rs
@@ -3,29 +3,29 @@ mod fixed_parameters;
 pub use self::fixed_parameters::*;
 use super::*;
 
-pub struct AssociationRequestFrame {
-    bytes: Bytes,
+pub struct AssociationRequestFrame<'a> {
+    bytes: &'a [u8],
 }
 
-impl AssociationRequestFrame {
-    pub fn new(bytes: Bytes) -> Self {
+impl<'a> AssociationRequestFrame<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
         Self { bytes }
     }
 }
-impl FrameTrait for AssociationRequestFrame {
-    fn bytes(&self) -> Bytes {
-        self.bytes.clone()
+impl FrameTrait for AssociationRequestFrame<'_> {
+    fn bytes(&self) -> &[u8] {
+        self.bytes
     }
 }
-impl FragmentSequenceTrait for AssociationRequestFrame {}
-impl ManagementFrameTrait for AssociationRequestFrame {}
-impl AssociationRequestFixedParametersTrait for AssociationRequestFrame {}
-impl TaggedParametersTrait for AssociationRequestFrame {
+impl FragmentSequenceTrait for AssociationRequestFrame<'_> {}
+impl ManagementFrameTrait for AssociationRequestFrame<'_> {}
+impl AssociationRequestFixedParametersTrait for AssociationRequestFrame<'_> {}
+impl TaggedParametersTrait for AssociationRequestFrame<'_> {
     const TAGGED_PARAMETERS_START: usize = Self::FIXED_PARAMETERS_END;
 }
 
 use std::fmt;
-impl fmt::Display for AssociationRequestFrame {
+impl fmt::Display for AssociationRequestFrame<'_> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "AssociationRequest")?;
 

--- a/src/management/association_response/mod.rs
+++ b/src/management/association_response/mod.rs
@@ -14,7 +14,7 @@ impl<'a> AssociationResponseFrame<'a> {
 }
 impl FrameTrait for AssociationResponseFrame<'_> {
     fn bytes(&self) -> &[u8] {
-        self.bytes.clone()
+        self.bytes
     }
 }
 impl FragmentSequenceTrait for AssociationResponseFrame<'_> {}

--- a/src/management/association_response/mod.rs
+++ b/src/management/association_response/mod.rs
@@ -3,23 +3,23 @@ mod fixed_parameters;
 pub use self::fixed_parameters::*;
 use super::*;
 
-pub struct AssociationResponseFrame {
-    bytes: Bytes,
+pub struct AssociationResponseFrame<'a> {
+    bytes: &'a [u8],
 }
 
-impl AssociationResponseFrame {
-    pub fn new(bytes: Bytes) -> Self {
+impl<'a> AssociationResponseFrame<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
         Self { bytes }
     }
 }
-impl FrameTrait for AssociationResponseFrame {
-    fn bytes(&self) -> Bytes {
+impl FrameTrait for AssociationResponseFrame<'_> {
+    fn bytes(&self) -> &[u8] {
         self.bytes.clone()
     }
 }
-impl FragmentSequenceTrait for AssociationResponseFrame {}
-impl ManagementFrameTrait for AssociationResponseFrame {}
-impl AssociationResponseFixedParametersTrait for AssociationResponseFrame {}
-impl TaggedParametersTrait for AssociationResponseFrame {
+impl FragmentSequenceTrait for AssociationResponseFrame<'_> {}
+impl ManagementFrameTrait for AssociationResponseFrame<'_> {}
+impl AssociationResponseFixedParametersTrait for AssociationResponseFrame<'_> {}
+impl TaggedParametersTrait for AssociationResponseFrame<'_> {
     const TAGGED_PARAMETERS_START: usize = Self::FIXED_PARAMETERS_END;
 }

--- a/src/management/authentication/mod.rs
+++ b/src/management/authentication/mod.rs
@@ -3,23 +3,23 @@ mod fixed_parameters;
 pub use self::fixed_parameters::*;
 use super::*;
 
-pub struct AuthenticationFrame {
-    bytes: Bytes,
+pub struct AuthenticationFrame<'a> {
+    bytes: &'a [u8],
 }
 
-impl AuthenticationFrame {
-    pub fn new(bytes: Bytes) -> Self {
+impl<'a> AuthenticationFrame<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
         Self { bytes }
     }
 }
-impl FrameTrait for AuthenticationFrame {
-    fn bytes(&self) -> Bytes {
+impl FrameTrait for AuthenticationFrame<'_> {
+    fn bytes(&self) -> &[u8] {
         self.bytes.clone()
     }
 }
-impl FragmentSequenceTrait for AuthenticationFrame {}
-impl ManagementFrameTrait for AuthenticationFrame {}
-impl AuthenticationFixedParametersTrait for AuthenticationFrame {}
-impl TaggedParametersTrait for AuthenticationFrame {
+impl FragmentSequenceTrait for AuthenticationFrame<'_> {}
+impl ManagementFrameTrait for AuthenticationFrame<'_> {}
+impl AuthenticationFixedParametersTrait for AuthenticationFrame<'_> {}
+impl TaggedParametersTrait for AuthenticationFrame<'_> {
     const TAGGED_PARAMETERS_START: usize = Self::FIXED_PARAMETERS_END;
 }

--- a/src/management/authentication/mod.rs
+++ b/src/management/authentication/mod.rs
@@ -14,7 +14,7 @@ impl<'a> AuthenticationFrame<'a> {
 }
 impl FrameTrait for AuthenticationFrame<'_> {
     fn bytes(&self) -> &[u8] {
-        self.bytes.clone()
+        self.bytes
     }
 }
 impl FragmentSequenceTrait for AuthenticationFrame<'_> {}

--- a/src/management/beacon/mod.rs
+++ b/src/management/beacon/mod.rs
@@ -3,22 +3,22 @@ mod fixed_parameters;
 pub use self::fixed_parameters::*;
 use super::*;
 
-pub struct BeaconFrame {
-    bytes: Bytes,
+pub struct BeaconFrame<'a> {
+    bytes: &'a [u8],
 }
 
-impl BeaconFrame {
-    pub fn new(bytes: Bytes) -> Self {
+impl<'a> BeaconFrame<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
         Self { bytes }
     }
 }
 
-impl FrameTrait for BeaconFrame {
-    fn bytes(&self) -> Bytes {
-        self.bytes.clone()
+impl FrameTrait for BeaconFrame<'_> {
+    fn bytes(&self) -> &[u8] {
+        self.bytes
     }
 }
-impl FragmentSequenceTrait for BeaconFrame {}
-impl ManagementFrameTrait for BeaconFrame {}
-impl BeaconFixedParametersTrait for BeaconFrame {}
-impl TaggedParametersTrait for BeaconFrame {}
+impl FragmentSequenceTrait for BeaconFrame<'_> {}
+impl ManagementFrameTrait for BeaconFrame<'_> {}
+impl BeaconFixedParametersTrait for BeaconFrame<'_> {}
+impl TaggedParametersTrait for BeaconFrame<'_> {}

--- a/src/management/beacon/mod.rs
+++ b/src/management/beacon/mod.rs
@@ -21,4 +21,6 @@ impl FrameTrait for BeaconFrame<'_> {
 impl FragmentSequenceTrait for BeaconFrame<'_> {}
 impl ManagementFrameTrait for BeaconFrame<'_> {}
 impl BeaconFixedParametersTrait for BeaconFrame<'_> {}
-impl TaggedParametersTrait for BeaconFrame<'_> {}
+impl TaggedParametersTrait for BeaconFrame<'_> {
+    const TAGGED_PARAMETERS_START: usize = 36;
+}

--- a/src/management/builder.rs
+++ b/src/management/builder.rs
@@ -24,7 +24,7 @@ impl ManagementFrameBuilder {
 
     #[must_use]
     pub fn build(&self) -> ManagementFrame {
-        ManagementFrame::new(self.bytes().to_vec())
+        ManagementFrame::new(self.bytes())
     }
 }
 impl FrameBuilderTrait for ManagementFrameBuilder {

--- a/src/management/deauthentication/builder.rs
+++ b/src/management/deauthentication/builder.rs
@@ -25,7 +25,7 @@ impl DeauthenticationFrameBuilder {
 
     #[must_use]
     pub fn build(&self) -> DeauthenticationFrame {
-        DeauthenticationFrame::new(self.bytes().to_vec())
+        DeauthenticationFrame::new(self.bytes())
     }
 }
 impl FrameBuilderTrait for DeauthenticationFrameBuilder {

--- a/src/management/deauthentication/mod.rs
+++ b/src/management/deauthentication/mod.rs
@@ -1,7 +1,7 @@
 mod builder;
 mod fixed_parameters;
 
-pub use self::fixed_parameters::*;
+pub use self::{builder::*, fixed_parameters::*};
 use super::*;
 
 pub struct DeauthenticationFrame<'a> {

--- a/src/management/deauthentication/mod.rs
+++ b/src/management/deauthentication/mod.rs
@@ -1,25 +1,25 @@
 mod builder;
 mod fixed_parameters;
 
-pub use self::{builder::*, fixed_parameters::*};
+pub use self::fixed_parameters::*;
 use super::*;
 
-pub struct DeauthenticationFrame {
-    bytes: Bytes,
+pub struct DeauthenticationFrame<'a> {
+    bytes: Cow<'a, [u8]>,
 }
 
-impl DeauthenticationFrame {
-    pub fn new<T: Into<Bytes>>(bytes: T) -> Self {
+impl<'a> DeauthenticationFrame<'a> {
+    pub fn new<T: Into<Cow<'a, [u8]>>>(bytes: T) -> Self {
         Self {
             bytes: bytes.into(),
         }
     }
 }
-impl FrameTrait for DeauthenticationFrame {
-    fn bytes(&self) -> Bytes {
-        self.bytes.clone()
+impl FrameTrait for DeauthenticationFrame<'_> {
+    fn bytes(&self) -> &[u8] {
+        self.bytes.as_ref()
     }
 }
-impl FragmentSequenceTrait for DeauthenticationFrame {}
-impl ManagementFrameTrait for DeauthenticationFrame {}
-impl DeauthenticationFixedParametersTrait for DeauthenticationFrame {}
+impl FragmentSequenceTrait for DeauthenticationFrame<'_> {}
+impl ManagementFrameTrait for DeauthenticationFrame<'_> {}
+impl DeauthenticationFixedParametersTrait for DeauthenticationFrame<'_> {}

--- a/src/management/disassociate/builder.rs
+++ b/src/management/disassociate/builder.rs
@@ -23,7 +23,7 @@ impl DisassociateFrameBuilder {
 
     #[must_use]
     pub fn build(&self) -> DisassociateFrame {
-        DisassociateFrame::new(self.bytes().to_vec())
+        DisassociateFrame::new(self.bytes())
     }
 }
 impl FrameBuilderTrait for DisassociateFrameBuilder {

--- a/src/management/disassociate/fixed_parameters.rs
+++ b/src/management/disassociate/fixed_parameters.rs
@@ -11,15 +11,3 @@ pub trait DisassociateFixedParametersTrait: FrameTrait {
         ))
     }
 }
-
-pub trait DisassociateFixedParametersBuilderTrait: FrameBuilderTrait {
-    const FIXED_PARAMETERS_START: usize = 24;
-    const FIXED_PARAMETERS_END: usize = Self::FIXED_PARAMETERS_START + 6;
-
-    fn reason_code(&mut self, reason_code: ReasonCode) {
-        LittleEndian::write_u16(
-            &mut self.bytes_mut()[Self::FIXED_PARAMETERS_START..(Self::FIXED_PARAMETERS_START + 2)],
-            reason_code.into_u16(),
-        )
-    }
-}

--- a/src/management/disassociate/fixed_parameters.rs
+++ b/src/management/disassociate/fixed_parameters.rs
@@ -11,3 +11,15 @@ pub trait DisassociateFixedParametersTrait: FrameTrait {
         ))
     }
 }
+
+pub trait DisassociateFixedParametersBuilderTrait: FrameBuilderTrait {
+    const FIXED_PARAMETERS_START: usize = 24;
+    const FIXED_PARAMETERS_END: usize = Self::FIXED_PARAMETERS_START + 6;
+
+    fn reason_code(&mut self, reason_code: ReasonCode) {
+        LittleEndian::write_u16(
+            &mut self.bytes_mut()[Self::FIXED_PARAMETERS_START..(Self::FIXED_PARAMETERS_START + 2)],
+            reason_code.into_u16(),
+        )
+    }
+}

--- a/src/management/disassociate/mod.rs
+++ b/src/management/disassociate/mod.rs
@@ -1,6 +1,7 @@
+mod builder;
 mod fixed_parameters;
 
-pub use self::fixed_parameters::*;
+pub use self::{builder::*, fixed_parameters::*};
 use super::*;
 
 pub struct DisassociateFrame<'a> {

--- a/src/management/disassociate/mod.rs
+++ b/src/management/disassociate/mod.rs
@@ -1,25 +1,24 @@
-mod builder;
 mod fixed_parameters;
 
-pub use self::{builder::*, fixed_parameters::*};
+pub use self::fixed_parameters::*;
 use super::*;
 
-pub struct DisassociateFrame {
-    bytes: Bytes,
+pub struct DisassociateFrame<'a> {
+    bytes: &'a [u8],
 }
 
-impl DisassociateFrame {
-    pub fn new<T: Into<Bytes>>(bytes: T) -> Self {
+impl<'a> DisassociateFrame<'a> {
+    pub fn new<T: Into<&'a [u8]>>(bytes: T) -> Self {
         Self {
             bytes: bytes.into(),
         }
     }
 }
-impl FrameTrait for DisassociateFrame {
-    fn bytes(&self) -> Bytes {
+impl FrameTrait for DisassociateFrame<'_> {
+    fn bytes(&self) -> &[u8] {
         self.bytes.clone()
     }
 }
-impl FragmentSequenceTrait for DisassociateFrame {}
-impl ManagementFrameTrait for DisassociateFrame {}
-impl DisassociateFixedParametersTrait for DisassociateFrame {}
+impl FragmentSequenceTrait for DisassociateFrame<'_> {}
+impl ManagementFrameTrait for DisassociateFrame<'_> {}
+impl DisassociateFixedParametersTrait for DisassociateFrame<'_> {}

--- a/src/management/disassociate/mod.rs
+++ b/src/management/disassociate/mod.rs
@@ -17,7 +17,7 @@ impl<'a> DisassociateFrame<'a> {
 }
 impl FrameTrait for DisassociateFrame<'_> {
     fn bytes(&self) -> &[u8] {
-        self.bytes.clone()
+        self.bytes
     }
 }
 impl FragmentSequenceTrait for DisassociateFrame<'_> {}

--- a/src/management/mod.rs
+++ b/src/management/mod.rs
@@ -15,31 +15,31 @@ pub use self::{
     tagged_parameters::*,
 };
 use super::*;
-use bytes::Bytes;
+use std::borrow::Cow;
 
-pub struct ManagementFrame {
-    bytes: Bytes,
+pub struct ManagementFrame<'a> {
+    bytes: Cow<'a, [u8]>,
 }
 
-pub enum ManagementFrameLayer {
-    Beacon(BeaconFrame),
-    ProbeRequest(ProbeRequestFrame),
-    ProbeResponse(ProbeResponseFrame),
-    Authentication(AuthenticationFrame),
-    Deauthentication(DeauthenticationFrame),
-    Disassociate(DisassociateFrame),
-    AssociationRequest(AssociationRequestFrame),
-    AssociationResponse(AssociationResponseFrame),
+pub enum ManagementFrameLayer<'a> {
+    Beacon(BeaconFrame<'a>),
+    ProbeRequest(ProbeRequestFrame<'a>),
+    ProbeResponse(ProbeResponseFrame<'a>),
+    Authentication(AuthenticationFrame<'a>),
+    Deauthentication(DeauthenticationFrame<'a>),
+    Disassociate(DisassociateFrame<'a>),
+    AssociationRequest(AssociationRequestFrame<'a>),
+    AssociationResponse(AssociationResponseFrame<'a>),
 }
 
-impl ManagementFrame {
-    pub fn new<T: Into<Bytes>>(bytes: T) -> Self {
+impl<'a> ManagementFrame<'a> {
+    pub fn new<T: Into<Cow<'a, [u8]>>>(bytes: T) -> Self {
         Self {
             bytes: bytes.into(),
         }
     }
 
-    pub fn next_layer(&self) -> Option<ManagementFrameLayer> {
+    pub fn next_layer(&self) -> Option<ManagementFrameLayer<'_>> {
         match self.subtype() {
             FrameSubtype::Management(subtype) => match subtype {
                 ManagementSubtype::Beacon => {
@@ -79,13 +79,13 @@ impl ManagementFrame {
     }
 }
 
-impl FrameTrait for ManagementFrame {
-    fn bytes(&self) -> Bytes {
-        self.bytes.clone()
+impl FrameTrait for ManagementFrame<'_> {
+    fn bytes(&self) -> &[u8] {
+        self.bytes.as_ref()
     }
 }
-impl FragmentSequenceTrait for ManagementFrame {}
-impl ManagementFrameTrait for ManagementFrame {}
+impl FragmentSequenceTrait for ManagementFrame<'_> {}
+impl ManagementFrameTrait for ManagementFrame<'_> {}
 
 pub trait ManagementFrameTrait: FrameTrait + FragmentSequenceTrait {
     fn addr2(&self) -> MacAddress {

--- a/src/management/probe_request.rs
+++ b/src/management/probe_request.rs
@@ -1,21 +1,21 @@
 use super::*;
 
-pub struct ProbeRequestFrame {
-    bytes: Bytes,
+pub struct ProbeRequestFrame<'a> {
+    bytes: &'a [u8],
 }
 
-impl ProbeRequestFrame {
-    pub fn new(bytes: Bytes) -> Self {
+impl<'a> ProbeRequestFrame<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
         Self { bytes }
     }
 }
-impl FrameTrait for ProbeRequestFrame {
-    fn bytes(&self) -> Bytes {
-        self.bytes.clone()
+impl FrameTrait for ProbeRequestFrame<'_> {
+    fn bytes(&self) -> &[u8] {
+        self.bytes
     }
 }
-impl FragmentSequenceTrait for ProbeRequestFrame {}
-impl ManagementFrameTrait for ProbeRequestFrame {}
-impl TaggedParametersTrait for ProbeRequestFrame {
+impl FragmentSequenceTrait for ProbeRequestFrame<'_> {}
+impl ManagementFrameTrait for ProbeRequestFrame<'_> {}
+impl TaggedParametersTrait for ProbeRequestFrame<'_> {
     const TAGGED_PARAMETERS_START: usize = 24;
 }

--- a/src/management/probe_response.rs
+++ b/src/management/probe_response.rs
@@ -17,4 +17,7 @@ impl FrameTrait for ProbeResponseFrame<'_> {
 impl FragmentSequenceTrait for ProbeResponseFrame<'_> {}
 impl ManagementFrameTrait for ProbeResponseFrame<'_> {}
 impl BeaconFixedParametersTrait for ProbeResponseFrame<'_> {}
-impl TaggedParametersTrait for ProbeResponseFrame<'_> {}
+impl TaggedParametersTrait for ProbeResponseFrame<'_> {
+    // TODO: Check that this is correct
+    const TAGGED_PARAMETERS_START: usize = 36;
+}

--- a/src/management/probe_response.rs
+++ b/src/management/probe_response.rs
@@ -1,20 +1,20 @@
 use super::*;
 
-pub struct ProbeResponseFrame {
-    bytes: Bytes,
+pub struct ProbeResponseFrame<'a> {
+    bytes: &'a [u8],
 }
 
-impl ProbeResponseFrame {
-    pub fn new(bytes: Bytes) -> Self {
+impl<'a> ProbeResponseFrame<'a> {
+    pub fn new(bytes: &'a [u8]) -> Self {
         Self { bytes }
     }
 }
-impl FrameTrait for ProbeResponseFrame {
-    fn bytes(&self) -> Bytes {
-        self.bytes.clone()
+impl FrameTrait for ProbeResponseFrame<'_> {
+    fn bytes(&self) -> &[u8] {
+        self.bytes
     }
 }
-impl FragmentSequenceTrait for ProbeResponseFrame {}
-impl ManagementFrameTrait for ProbeResponseFrame {}
-impl BeaconFixedParametersTrait for ProbeResponseFrame {}
-impl TaggedParametersTrait for ProbeResponseFrame {}
+impl FragmentSequenceTrait for ProbeResponseFrame<'_> {}
+impl ManagementFrameTrait for ProbeResponseFrame<'_> {}
+impl BeaconFixedParametersTrait for ProbeResponseFrame<'_> {}
+impl TaggedParametersTrait for ProbeResponseFrame<'_> {}

--- a/tests/main_test.rs
+++ b/tests/main_test.rs
@@ -53,7 +53,7 @@ fn check<T: std::fmt::Debug + std::cmp::PartialEq>(original: Option<T>, test: Op
 
 #[allow(clippy::cognitive_complexity)]
 fn test_test_item(test_item: TestItem) {
-    let frame = Frame::new(test_item.bytes.to_vec());
+    let frame = Frame::new(test_item.bytes);
 
     if let Some(version) = test_item.version {
         assert_eq!(frame.version(), version, "version");


### PR DESCRIPTION
Hey :)

I've noticed your code does a lot of allocations and copies when parsing a packet.
I've needed to process a massive amount of packets, so I replaced `Bytes` with `Cow<[u8]>` everywhere and dropped the `bytes` dependency.

Initially I fixed that for my own use and didn't think I'd make a PR, so I let the auto-formatter run when I comitted, and it wreaked havoc on your 2-space indentation.

In order to reduce allocations further, I also moved the tagged parameters into an iteration API (re-implemented the previous method returning a HashMap above that)
This PR also adds another function to management frames that iterates over tagged parameters whatever the underlying subtype is.

Overall my commit history is very messy, and some of the changes were for my very specific use case.
I don't expect you' to merge this as is, but am willing to work a little to refine it.

Anyway, the performance improvements are very noticeable. (*EDIT*: though the "new beacon" bench is a bit bare)

Thoughts?

![image](https://user-images.githubusercontent.com/1339859/76891731-298f6a00-6892-11ea-91b8-89c1ff8ab074.png)
